### PR TITLE
202205 benkmugo extension updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ example strucutre
         * ger-DE
         * fre-FR
 
+2.1) Re-generate eZ Publish's autoload array to make the extensions classes available.
+
+php bin/php/ezpgenerateautoloads.php -e -p 
 
 3) Use following script to extract all translation strings from 'myextension':
 
@@ -37,3 +40,21 @@ In short, the "csv" module converts a .ts file by looking at the path: &lt;exten
 
 So for the base translation export, you would load a URL like this:
 mugo_i18n/csv/mugoqueue/untranslated
+
+
+Advanced use example
+--------------------
+Creating:
+- a new translations file for the demoextension (-t)
+- taking an existing translations file for the extension into account (-e)
+- extending the .tpl regex patterns (-x) used to find strings marked by a custom translation operator (lcb18n)
+- and extending the .php regex patterns (-X) used to find strings marked by a custom translation method (LCB18n::tr)
+
+php extension/mugo_i18n/scripts/create_translation_file.php \
+-t demoextension \
+-e extension/demoextension/translations/fre-CA/translation.ts \
+-x $'#["]([^"]+)["]\|lcb18n\([ |]*[\\\'|"](.*?)[\\\'|"][ |]*[,|\)]#' \
+-x $'#[\\\']([^\\\']+)[\\\']\|lcb18n\([ |]*[\\\'|"](.*?)[\\\'|"][ |]*[,|\)]#' \
+-X $'#(?:LCB18n::tr|lcb18n)\( *[\\\'|"](.*?)[\\\'|"] *, *[\\\'|"](.*?)[\\\'|"] *[,|\)]#is' > extension/demoextension/translations/fre-CA/translation.new
+
+See php extension/mugo_i18n/scripts/create_translation_file.php -h for all available flags

--- a/classes/mugoi18ntranslationfilehandler.php
+++ b/classes/mugoi18ntranslationfilehandler.php
@@ -1,0 +1,412 @@
+<?php 
+
+/**
+ * Handles parsing eZ templates and PHP files for translations strings
+ * as well as building eZ translation files
+ */
+class MugoI18nTranslationFileHandler
+{
+    public $extendedPatterns;
+    public $overridePatterns;
+
+    public function __construct()
+    {
+        $this->extendedPatterns = array
+        (
+            '.tpl'   => array()
+            , '.php' => array()
+        );
+        $this->overridePatterns = array
+        (
+            '.tpl'   => array()
+            , '.php' => array()
+        );
+    }
+
+    /**
+     * Returns a list of translatable strings with their context
+     * 
+     * @param  array $extensions Extensions to check
+     * @param  array $contexts   Contexts to check
+     * 
+     * @return array             Translateable strings by context
+     */
+    public function getTranslationStrings( $extensions, $contexts = array() )
+    {
+        $result         = array();
+        $fileExtensions = array( '.tpl', '.php' );
+
+        foreach( $extensions as $extension )
+        {
+            foreach( $fileExtensions as $fileExtension )
+            {
+                $files = self::listExtensionFiles( $extension, array( $fileExtension ) );
+                foreach( $files as $file )
+                {
+                    switch( $fileExtension )
+                    {
+                        case '.tpl':
+                        {
+                            $extendPatterns   = ( $this->extendedPatterns[ $fileExtension ] )? $this->extendedPatterns[ $fileExtension ] : array();
+                            $overridePatterns = ( $this->overridePatterns[ $fileExtension ] )? $this->overridePatterns[ $fileExtension ] : array();
+                            $instances        = self::getTPLStrings( $file, $extendPatterns, $overridePatterns );
+                        }
+                        break;
+
+                        case '.php':
+                        {
+                            $extendPatterns   = ( $this->extendedPatterns[ $fileExtension ] )? $this->extendedPatterns[ $fileExtension ] : array();
+                            $overridePatterns = ( $this->overridePatterns[ $fileExtension ] )? $this->overridePatterns[ $fileExtension ] : array();
+                            $instances        = self::getPHPStrings( $file, $extendPatterns, $overridePatterns );
+                        }
+                        break;
+                    }
+
+                    foreach( $instances as $instance )
+                    {
+                        if( !self::translationExits( $instance[ 'context' ], $instance[ 'source' ] ) )
+                        {
+                            if( empty( $contexts ) || in_array( $instance[ 'context' ], $contexts, false ) )
+                            {
+                                $result[ $instance[ 'context' ] ][ md5( $instance[ 'source' ] ) ] = $instance;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns a list of files found in the given extension based on their file extension
+     * 
+     * @param  string $extensionName  Extension to search
+     * @param  array  $fileExtension  Extension of files to find and return
+     * 
+     * @return array                  List of files
+     */
+    private static function listExtensionFiles( $extensionName, $fileExtension )
+    {
+        $files           = array();
+        $directoryHandle = @opendir( 'extension/' . $extensionName ) or die( "Unable to open extension/{$extensionName}" );
+        $files           = self::recursionList( $directoryHandle, 'extension/' . $extensionName, $fileExtension );
+
+        closedir( $directoryHandle );
+
+        return $files;
+    }
+
+    /**
+     * Returns a list of files found in the given directory/path recursively based on their file extension
+     * 
+     * @param  handle $directoryHandle Directory handle
+     * @param  string $path            Directory path
+     * @param  array  $fileExtension   Extension of files to find and return
+     * 
+     * @return array                   List of files found
+     */
+    private static function recursionList( $directoryHandle, $path, $fileExtension )
+    {
+        $return = array();
+
+        while( false !== ( $file = readdir( $directoryHandle ) ) )
+        {
+            $dir = $path . '/' . $file;
+
+            if( is_dir( $dir ) && $file != '.' && $file !='..' && $file != '.svn' && $file != '.git' )
+            {
+                $handle = @opendir( $dir ) or die( "unable to open file $file" );
+                $return = array_merge( self::recursionList( $handle, $dir, $fileExtension ), $return );
+            }
+            elseif( in_array( substr( $file, -4 ), $fileExtension ) )
+            {
+                $return[] = $dir;
+            }
+        }
+
+        return $return;
+    }
+
+    /**
+     * Searches given file for strings marked with the ezpI18n::tr or ezi18n translation functions
+     * 
+     * @param  string $file             File to check for string marked for translation
+     * @param  array  $extendPatterns   Array of regex patterns to use in addition to the defaults
+     * @param  array  $overridePatterns Array of regex patterns to use instead of the defaults
+     * 
+     * @return array                    Matches strings
+     */
+    public static function getPHPStrings( $file, $extendPatterns = array(), $overridePatterns = array() )
+    {
+        $return  = array();
+        $content = file_get_contents( $file );
+        
+        $patterns = array
+        (
+            '#(?:ezpI18n::tr|ezi18n)\( *[\'|"](.*?)[\'|"] *, *[\'|"](.*?)[\'|"] *[,|\)]#is'
+        );
+
+        if ( $extendPatterns )
+        {
+            $patterns = array_merge( $patterns, $extendPatterns );
+        }
+        elseif ( $overridePatterns )
+        {
+            $patterns = $overridePatterns;
+        }
+
+        $matches = array();
+        foreach( $patterns as $index => $pattern )
+        {
+            preg_match_all( $pattern, $content, $matches[ $index ], PREG_OFFSET_CAPTURE );
+        }
+
+        foreach( $matches as $pattern_matches )
+        {
+            if( !empty( $pattern_matches[ 0 ] ) )
+            {
+                foreach( $pattern_matches[ 0 ] as $index => $values )
+                {
+                    $return[ $values[ 1 ] ] = array
+                    (
+                        'file'    => $file
+                      , 'offset'  => $values[ 1 ]
+                      , 'source'  => $pattern_matches[ 2 ][ $index ][ 0 ]
+                      , 'context' => $pattern_matches[ 1 ][ $index ][ 0 ]
+                    );
+                }
+            }
+        }
+
+        // sort by key (offset) so that results are in the order found in the file regardless of pattern
+        ksort( $return );
+
+        return $return;
+    }
+
+    /**
+     * Searches given file for strings marked with the i18n template operator
+     * 
+     * @param  string $file             File to check for string marked for translation
+     * @param  array  $extendPatterns   Array of regex patterns to use in addition to the defaults
+     * @param  array  $overridePatterns Array of regex patterns to use instead of the defaults
+     * 
+     * @return array                    Matches strings
+     */
+    public static function getTPLStrings( $file, $extendPatterns = array(), $overridePatterns = array() )
+    {
+        $return  = array();
+        $content = file_get_contents( $file );
+
+        // updated regex to match more variations of translation markers e.g. in arrays or hashes
+        // split into two regex to handle double-quoted string with single quotes and single-quoted string
+        // with double quotes.
+        $patterns = array
+        (
+            // double-quoted strings
+            '#["]([^"]+)["]\|i18n\([ |]*[\'|"](.*?)[\'|"][ |]*[,|\)]#'
+            // single-quoted string
+            , '#[\']([^\']+)[\']\|i18n\([ |]*[\'|"](.*?)[\'|"][ |]*[,|\)]#'
+        );
+
+        if ( $extendPatterns )
+        {
+            $patterns = array_merge( $patterns, $extendPatterns );
+        }
+        elseif ( $overridePatterns )
+        {
+            $patterns = $overridePatterns;
+        }
+
+        $matches = array();
+        foreach( $patterns as $index => $pattern )
+        {
+            preg_match_all( $pattern, $content, $matches[ $index ], PREG_OFFSET_CAPTURE );
+        }
+
+        foreach( $matches as $pattern_matches )
+        {
+            if( !empty( $pattern_matches[ 0 ] ) )
+            {
+                foreach( $pattern_matches[ 0 ] as $index => $values )
+                {
+                    $return[ $values[ 1 ] ] = array
+                    (
+                        'file'    => $file
+                      , 'offset'  => $values[ 1 ]
+                      , 'source'  => $pattern_matches[ 1 ][ $index ][ 0 ]
+                      , 'context' => $pattern_matches[ 2 ][ $index ][ 0 ]
+                    );
+                }
+            }
+        }
+
+        // sort by key (offset) so that results are in the order found in the file regardless of pattern
+        ksort( $return );
+
+        return $return;
+    }
+
+    /**
+     * Builds and outputs the translation file XML
+     * 
+     * @param  array  $translationStrings String marked for translation by context
+     * @param  string $defaultTranslation Default translation used for sources without translation
+     * @param  string $existingTSFile     An existing translation file to check and use for translations when creating the new translations
+     */
+    public static function buildTranslationFile( $translationStrings, $defaultTranslation = '', $existingTSFile = '' )
+    {
+        $implementation    = new DOMImplementation();
+        $dtd               = $implementation->createDocumentType( 'TS' );
+        $doc               = $implementation->createDocument( null, 'TS', $dtd );
+        $doc->encoding     = 'utf-8';
+        $doc->formatOutput = true;
+        
+        $tsNode = $doc->childNodes->item( 1 );
+
+        $existingTSDoc = ( $existingTSFile )? self::loadExistingTranslationFile( $existingTSFile ) : false;
+
+        // build contexts
+        foreach( $translationStrings as $context => $entries )
+        {
+            $contextNode = $doc->createElement( 'context' );
+            $nameNode    = $doc->createElement( 'name' );
+            $nameNode->appendChild( $doc->createTextNode( $context ) );
+            $contextNode->appendChild( $nameNode );
+
+            // build messages
+            foreach( $entries as $entry )
+            {
+                $messageNode     = $doc->createElement( 'message' );
+                $sourceNode      = $doc->createElement( 'source' );
+                $translationNode = $doc->createElement( 'translation' );
+
+                $sourceNode->appendChild( $doc->createTextNode( $entry[ 'source' ] ) );
+
+                $existingTranslation = '';
+                if ( $existingTSDoc )
+                {
+                    $existingTranslation = self::findExistingTranslation( $existingTSDoc, $context, $entry[ 'source' ] );
+                }
+
+                if ( $existingTranslation )
+                {
+                    $translationNode->appendChild( $doc->createTextNode(  $existingTranslation ) );
+                    $translationNode->setAttribute( 'type', 'finished' );
+                }
+                else
+                {
+                    $translationNode->appendChild( $doc->createTextNode( $defaultTranslation ) );
+                    $translationNode->setAttribute( 'type', 'unfinished' );
+                }
+                
+                if( $entry[ 'file' ] )
+                {
+                    $locationNode = $doc->createElement( 'location' );
+                    $locationNode->setAttribute( 'filename', $entry[ 'file' ] );
+                    $locationNode->setAttribute( 'line', $entry[ 'offset' ] );
+
+                    $messageNode->appendChild( $locationNode );
+                }
+
+                $messageNode->appendChild( $sourceNode );
+                $messageNode->appendChild( $translationNode );
+
+                $contextNode->appendChild( $messageNode );
+            }
+
+            $tsNode->appendChild( $contextNode );
+        }
+
+        echo $doc->saveXML();
+    }
+
+    /**
+     * Loads a translations file into a DOMDocument
+     * 
+     * @param  string $filepath Path to an existing translations file
+     * 
+     * @return object           DOMDocument of existing translations file
+     */
+    private static function loadExistingTranslationFile( $filename )
+    {
+        $doc                     = new DOMDocument();
+        $doc->preserveWhiteSpace = false;
+        $doc->formatOutput       = true;
+
+        $xml = file_get_contents( $filename );
+        // replacing single quotes in name or source tags, because XPath 1.0 does not support
+        // escaping quotes, but we need to find sources via XPath queries that may contain them.
+        // 
+        // no support for non-capturing groups, but we want to keep the replacements specific,
+        // so multiple groups it is ...
+        $xml = preg_replace( "/(<(name|source)>.*)(['])(.*<\/(name|source)>)/im", '$1#SQ#$4', $xml );
+
+        // check structure
+        libxml_use_internal_errors( true );
+        $simplexml = simplexml_load_string( $xml );
+
+        if( $simplexml === false )
+        {
+            $errors = libxml_get_errors();
+            foreach( $errors as $error )
+            {
+                echo "Bad XML in existing TS file: " . trim( $error->message ) . "\n";
+            }
+
+            return false;
+        }
+
+        $doc->loadXML( $xml );
+
+        return $doc;
+    }
+
+    /**
+     * Run a single XPath query against a DOMDocument returning a single result
+     * 
+     * @param  object $doc   DOMDocument to query
+     * @param  string $query XPath query to run against the DOMDocument
+     * 
+     * @return string        XPath query result
+     */
+    private static function findExistingTranslation( $doc, $context, $source )
+    {
+        $result         = '';
+        $quoteMarker    = '#SQ#';
+        $escapedContext = str_replace( "'", $quoteMarker, $context );
+        $escapedSource  = str_replace( "'", $quoteMarker, $source );
+
+        $xpath       = new DOMXPath( $doc );
+        $query       = "//TS/context/name[text() = '{$escapedContext}']//following-sibling::message/source[text() = '{$escapedSource}']//following-sibling::translation[normalize-space(text()) != '']";
+        $queryResult = $xpath->query( $query );
+
+        if( $queryResult && $queryResult->length )
+        {
+            $result = $queryResult->item( 0 )->nodeValue;
+            $result = str_replace( $quoteMarker, "'", $result );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Checks if the eZTranslationManager has an existing translation for the given source
+     * 
+     * @param  string $context Translation context
+     * @param  string $source  Translation source
+     * 
+     * @return boolean         Translation check result
+     */
+    public static function translationExits( $context, $source )
+    {
+        $translationManager = eZTranslatorManager::instance();
+        $translation        = $translationManager->translate( $context, $source );
+
+        return $translation !== null;
+    }
+}
+
+?>

--- a/design/standard/javascript/jquery.mugo_i18n.js
+++ b/design/standard/javascript/jquery.mugo_i18n.js
@@ -92,10 +92,11 @@
                 // collect dirty data
                 var data =
                 {
-                    locale    : $( '#localelist option:selected' ).val()
-                  , extension : $( '#extensionlist option:selected' ).val()
-                  , ids       : []
-                  , values    : []
+                    locale        : $( '#localelist option:selected' ).val()
+                  , extension     : $( '#extensionlist option:selected' ).val()
+                  , ids           : []
+                  , values        : []
+                  , ezxform_token : $( '#ezxform_token_js' ).attr( 'title' )
                 };
 
                 $( self.element ).find( 'input[data-dirty = 1]' ).each( function()

--- a/extension.xml
+++ b/extension.xml
@@ -2,7 +2,7 @@
 <software>
     <metadata>
         <name>&lt;a href="http://www.mugo.ca"&gt;Mugo i18n Tools&lt;/a&gt;</name>
-        <version>1.0</version>
+        <version>1.1</version>
         <copyright>Copyright (C) 2013 &lt;a href="http://www.mugo.ca"&gt;Mugo Web&lt;/a&gt;</copyright>
         <license>GNU General Public License v2.0</license>
         <software/>

--- a/ezinfo.php
+++ b/ezinfo.php
@@ -11,7 +11,7 @@ class mugo_i18nInfo
     static function info()
     {
         return array( 'Name'      => "<a href='http://www.mugo.ca'>Mugo i18n Tools</a>"
-                    , 'Version'   => '1.0'
+                    , 'Version'   => '1.1'
                     , 'Copyright' => "Copyright (C) <a href='http://www.mugo.ca'>Mugo Web</a>"
                     , 'License'   => 'GNU General Public License v2.0'
                     );

--- a/scripts/create_translation_file.php
+++ b/scripts/create_translation_file.php
@@ -1,272 +1,102 @@
 <?php
 
-#################
-#  Setting up env
-#################
+require_once( 'autoload.php' );
 
-require 'autoload.php';
+$parameters = new ezcConsoleInput();
 
-$params = new ezcConsoleInput();
-
-$helpOption = new ezcConsoleOption( 'h', 'help' );
+$helpOption            = new ezcConsoleOption( 'h', 'help' );
 $helpOption->mandatory = false;
 $helpOption->shorthelp = "Show help information";
-$params->registerOption( $helpOption );
+$parameters->registerOption( $helpOption );
 
-$targetOption = new ezcConsoleOption( 't', 'target', ezcConsoleInput::TYPE_STRING );
+$targetOption            = new ezcConsoleOption( 't', 'target', ezcConsoleInput::TYPE_STRING );
 $targetOption->mandatory = true;
 $targetOption->shorthelp = "The target extensions, comma separated list";
-$params->registerOption( $targetOption );
+$parameters->registerOption( $targetOption );
 
-//dfearnley: Added 'targetContexts' to limit the output to one or more contexts. Passed using -c as comma separated list.
-$targetContexts = new ezcConsoleOption( 'c', 'context', ezcConsoleInput::TYPE_STRING );
-$targetContexts->mandatory = false;
-$targetContexts->shorthelp = "All contexts are returned by default.  Use this option to limit the output to the provided list.";
-$params->registerOption( $targetContexts );
+$targetContextsOption            = new ezcConsoleOption( 'c', 'context', ezcConsoleInput::TYPE_STRING );
+$targetContextsOption->mandatory = false;
+$targetContextsOption->default   = '';
+$targetContextsOption->shorthelp = "All contexts are returned by default.  Use this option to limit the output to the comma separated list provided.";
+$parameters->registerOption( $targetContextsOption );
 
-$default_translation = new ezcConsoleOption( 'd', 'default_translation', ezcConsoleInput::TYPE_STRING );
-$default_translation->mandatory = false;
-$default_translation->shorthelp = "Set a default translation for all strings.";
-$params->registerOption( $default_translation );
+$defaultTranslationOption            = new ezcConsoleOption( 'd', 'default-translation', ezcConsoleInput::TYPE_STRING );
+$defaultTranslationOption->mandatory = false;
+$defaultTranslationOption->default   = '';
+$defaultTranslationOption->shorthelp = "Set a default translation for all strings.";
+$parameters->registerOption( $defaultTranslationOption );
+
+$existingTranslationsFileOption            = new ezcConsoleOption( 'e', 'existing-translations-file', ezcConsoleInput::TYPE_STRING );
+$existingTranslationsFileOption->mandatory = false;
+$existingTranslationsFileOption->default   = '';
+$existingTranslationsFileOption->shorthelp = "An existing translations file to check for translations.";
+$parameters->registerOption( $existingTranslationsFileOption );
+
+$extendPatternsTPLOption            = new ezcConsoleOption( 'x', 'extend-patterns-tpl', ezcConsoleInput::TYPE_STRING );
+$extendPatternsTPLOption->mandatory = false;
+$extendPatternsTPLOption->multiple  = true;
+$extendPatternsTPLOption->default   = array();
+$extendPatternsTPLOption->shorthelp = "A regex pattern of template operator calls to search for, extending the existing list of patterns; (multi-option)";
+$parameters->registerOption( $extendPatternsTPLOption );
+
+$extendPatternsPHPOption            = new ezcConsoleOption( 'X', 'extend-patterns-php', ezcConsoleInput::TYPE_STRING );
+$extendPatternsPHPOption->mandatory = false;
+$extendPatternsPHPOption->multiple  = true;
+$extendPatternsPHPOption->default   = array();
+$extendPatternsPHPOption->shorthelp = "A regex pattern of PHP function calls to search for, extending the existing list of patterns; (multi-option)";
+$parameters->registerOption( $extendPatternsPHPOption );
+
+$overridePatternsTPLOption            = new ezcConsoleOption( 'o', 'override-patterns-tpl', ezcConsoleInput::TYPE_STRING );
+$overridePatternsTPLOption->mandatory = false;
+$overridePatternsTPLOption->multiple  = true;
+$overridePatternsTPLOption->default   = array();
+$overridePatternsTPLOption->shorthelp = "A regex pattern of template operator calls to search for, overriding the existing list of patterns; (multi-option)";
+$parameters->registerOption( $overridePatternsTPLOption );
+
+$overridePatternsPHPOption            = new ezcConsoleOption( 'O', 'override-patterns-php', ezcConsoleInput::TYPE_STRING );
+$overridePatternsPHPOption->mandatory = false;
+$overridePatternsPHPOption->multiple  = true;
+$overridePatternsPHPOption->default   = array();
+$overridePatternsPHPOption->shorthelp = "A regex pattern of PHP function calls to search for, overriding the existing list of patterns; (multi-option)";
+$parameters->registerOption( $overridePatternsPHPOption );
 
 // Process console parameters
 try
 {
-    $params->process();
+    $parameters->process();
 }
 catch ( ezcConsoleOptionException $e )
 {
-    print( $e->getMessage(). "\n" );
-    print( "\n" );
+    echo $e->getMessage() . "\n\n";
+    echo $parameters->getHelpText( 'TS file generator.' ) . "\n\n";
 
-    echo $params->getHelpText( 'TS file generator.' ) . "\n";
-
-    echo "\n";
     exit();
 }
 
-####################
-# Script process
-####################
+$translationFileHandler = new MugoI18nTranslationFileHandler();
 
-$extensions      = explode( ',', $targetOption->value );
-$contexts        = array();
-if( $targetContexts->value )
+$extensions = explode( ',', $targetOption->value );
+$contexts   = ( $targetContextsOption->value )? explode( ',', $targetContextsOption->value ) : array();
+
+// Set extended patterns
+if ( $extendPatternsTPLOption->value ) { $translationFileHandler->extendedPatterns[ '.tpl' ] = $extendPatternsTPLOption->value; }
+if ( $extendPatternsPHPOption->value ) { $translationFileHandler->extendedPatterns[ '.php' ] = $extendPatternsPHPOption->value; }
+
+// Set override patterns
+if ( $overridePatternsTPLOption->value ){ $translationFileHandler->overridePatterns[ '.tpl' ] = $overridePatternsTPLOption->value; }
+if ( $overridePatternsPHPOption->value ){ $translationFileHandler->overridePatterns[ '.php' ] = $overridePatternsPHPOption->value; }
+
+// Find translations strings
+$translationStrings = $translationFileHandler->getTranslationStrings( $extensions, $contexts );
+
+// Return translation file contents or failure message.
+if ( $translationStrings )
 {
-    $contexts = explode( ',', $targetContexts->value );
+    MugoI18nTranslationFileHandler::buildTranslationFile( $translationStrings, $defaultTranslationOption->value, $existingTranslationsFileOption->value );
 }
-$file_extensions = array( '.tpl', '.php' );
-
-// extract strings from files and store them in $results
-$result = array();
-foreach( $extensions as $extension )
+else
 {
-    foreach( $file_extensions as $file_extension )
-    {
-        $files = Create_Translation_File_Handler::list_extension_files( $extension, array( $file_extension ) );
-
-        foreach( $files as $file )
-        {
-            switch( $file_extension )
-            {
-                case '.tpl':
-                {
-                    $i18n_instances = get_i18n_strings( $file );
-                }
-                break;
-
-                case '.php':
-                {
-                    $i18n_instances = get_i18n_strings_in_php( $file );
-                }
-                break;
-            }
-
-            foreach( $i18n_instances as $instance )
-            {
-                if( !translation_exits( $instance[ 'context' ], $instance[ 'source' ] ) )
-                {                    
-                    if( empty( $contexts ) || in_array( $instance[ 'context' ], $contexts, false ) )
-                    {
-                        $result[ $instance[ 'context' ] ][ md5( $instance[ 'source' ] ) ] = $instance;
-                    }
-                }
-            }
-        }
-    }
+    echo "No translation strings found.\n";
 }
 
-// Sort strings per context
-#foreach( $result as &$context )
-#{
-#    sort( $context );
-#}
-
-build_ts_file( $result, $default_translation->value );
-
-
-########################
-# Functions
-########################
-
-function get_i18n_strings_in_php( $file )
-{
-    $return = array();
-
-    $content = file_get_contents( $file );
-    
-    preg_match_all( '#(?:ezpI18n::tr|ezi18n)\( *[\'|"](.*?)[\'|"] *, *[\'|"](.*?)[\'|"] *[,|\)]#is', $content, $instances, PREG_OFFSET_CAPTURE );
-
-    if( !empty( $instances[ 0 ] ) )
-    {
-        foreach( $instances[ 0 ] as $index => $values )
-        {
-            $return[] = array(
-                'file'    => $file
-              , 'offset'  => $values[ 1 ]
-              , 'source'  => $instances[ 2 ][ $index ][ 0 ]
-              , 'context' => $instances[ 1 ][ $index ][ 0 ]
-            );
-        }
-    }
-
-    return $return;
-}
-
-/**
- * 
- * @param type $file
- * @return array
- */
-function get_i18n_strings( $file )
-{
-    $return = array();
-    
-    $content = file_get_contents( $file );
-    
-    //dfearnley: Removed the { from the beginning of the match string to capture instances that are nested within other lines of code
-    preg_match_all( '#[\'|"]([^{]+)[\'|"]\|i18n\([ |]*[\'|"](.*?)[\'|"][ |]*[,|\)]#', $content, $instances, PREG_OFFSET_CAPTURE );
-
-    if( !empty( $instances[ 0 ] ) )
-    {
-        foreach( $instances[ 0 ] as $index => $values )
-        {
-            $return[] = array(
-                'file'    => $file
-              , 'offset'  => $values[ 1 ]
-              , 'source'  => $instances[ 1 ][ $index ][ 0 ]
-              , 'context' => $instances[ 2 ][ $index ][ 0 ]
-            );
-        }
-    }
-
-    return $return;
-}
-
-function build_ts_file( $result, $default_translation = '' )
-{
-    $implementation = new DOMImplementation();
-    $dtd = $implementation->createDocumentType( 'TS' );
-    $doc = $implementation->createDocument( null, 'TS', $dtd );
-    $doc->encoding = 'utf-8';
-    $doc->formatOutput = true;
-    
-    $tsNode = $doc->childNodes->item( 1 );
-    
-    // build contexts
-    foreach( $result as $context => $entries )
-    {
-        $contextNode = $doc->createElement( 'context' );
-        $nameNode = $doc->createElement( 'name' );
-        $nameNode->appendChild( $doc->createTextNode( $context ) );
-        $contextNode->appendChild( $nameNode );
-
-        // build messages
-        foreach( $entries as $entry )
-        {
-            $messageNode     = $doc->createElement( 'message' );
-            $sourceNode      = $doc->createElement( 'source' );
-            $translationNode = $doc->createElement( 'translation' );
-
-            $sourceNode->appendChild( $doc->createTextNode( $entry[ 'source' ] ) );
-            $translationNode->appendChild( $doc->createTextNode( $default_translation ) );
-            $translationNode->setAttribute( 'type', 'unfinished' );
-            
-            if( $entry[ 'file' ] )
-            {
-                $locationNode = $doc->createElement( 'location' );
-                $locationNode->setAttribute( 'filename', $entry[ 'file' ] );
-                $locationNode->setAttribute( 'line', $entry[ 'offset' ] );
-
-                $messageNode->appendChild( $locationNode );
-            }
-
-            $messageNode->appendChild( $sourceNode );
-            $messageNode->appendChild( $translationNode );
-
-            $contextNode->appendChild( $messageNode );
-        }
-
-        $tsNode->appendChild( $contextNode );
-    }
-
-    echo $doc->saveXML();
-}
-
-/**
- * 
- * @param string $context
- * @param string $source
- * @return boolean
- */
-function translation_exits( $context, $source )
-{
-    $man = eZTranslatorManager::instance();
-    $trans = $man->translate( $context, $source );
-
-    return $trans !== null;
-}
-
-class Create_Translation_File_Handler
-{
-
-    static function list_extension_files( $extension_name, $file_extensions )
-    {
-        $files = array();
-        //this line was causing a $path not defined error, so '$path' changed to 'path'
-        $dir_handle = @opendir( 'extension/' . $extension_name ) or die( "Unable to open path" );
-
-        $files = self::recursion_list( $dir_handle, 'extension/' . $extension_name, $file_extensions );
-
-        closedir( $dir_handle );
-
-        return $files;
-    }
-
-    static function recursion_list( $dir_handle, $path, $file_extensions )
-    {
-        $return = array();
-        //running the while loop
-        while( false !== ( $file = readdir( $dir_handle ) ) )
-        {
-            $dir = $path.'/'.$file;
-
-            if( is_dir( $dir ) && $file != '.' && $file !='..' && $file != '.svn' )
-            {
-                $handle = @opendir($dir) or die( "undable to open file $file" );
-                //echo "D: $file\n";
-
-                $return = array_merge( self::recursion_list( $handle, $dir, $file_extensions), $return );
-            }
-            elseif( in_array( substr( $file, -4 ), $file_extensions ) )
-            {
-                //TODO: still takes ini files
-                //echo "F: $file\n";
-                $return[] = $dir;
-            }
-        }
-
-        return $return;
-    }
-}
 ?>


### PR DESCRIPTION
A number of additions to the translation file creator script that allow:

- creating a new translation file based on an existing translations file (keeping already translated content safe)
- extending the regex patterns used to find the default eZ Publish translation operator and method
- overriding the regex patterns used to find the default eZ Publish translation operator and method